### PR TITLE
Add GNOME application concept using Python

### DIFF
--- a/gnome/LindosTrayApp/app.py
+++ b/gnome/LindosTrayApp/app.py
@@ -1,0 +1,57 @@
+import darkdetect
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk
+
+
+class LindosTrayApp(Gtk.Window):
+    def __init__(self):
+        """A borderless window with a text box that reacts on key strokes."""
+        super().__init__(title=None)
+        self.set_decorated(False)  # no title bar and borders
+        self.set_default_size(300, 100)
+
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        self.add(vbox)
+
+        self.text_entry = Gtk.Entry()
+        self.text_entry.set_placeholder_text("Ask me anything...")
+        self.text_entry.connect("changed", self.on_text_changed)
+        vbox.pack_start(self.text_entry, True, True, 0)
+
+        self.connect("key-press-event", self.on_key_press)
+
+        self.apply_theme(darkdetect.theme())
+
+    def apply_theme(self, theme: str):
+        """Set background color based on the theme."""
+        if theme == "Light":
+            print("Light theme detected")
+        elif theme == "Dark":
+            print("Dark theme detected")
+        else:
+            raise NotImplementedError(f"Unsupported theme '{theme}'")
+
+    def on_text_changed(self, widget):
+        """Get the current text from the entry."""
+        text = widget.get_text()
+        self.call_external_library(text)
+
+    def call_external_library(self, text):
+        # Replace this print statement with your external library call
+        print(f"Text changed: {text}")
+
+    def on_key_press(self, widget, key_event):
+        """Close application window on Escape key or Ctrl+Space."""
+        if key_event.keyval == Gdk.KEY_Escape or (
+            key_event.keyval == Gdk.KEY_space
+            and key_event.state & Gdk.ModifierType.CONTROL_MASK
+        ):
+            self.close()
+
+
+win = LindosTrayApp()
+win.connect("destroy", Gtk.main_quit)
+win.show_all()
+Gtk.main()

--- a/gnome/flake.lock
+++ b/gnome/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761672384,
+        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/gnome/flake.nix
+++ b/gnome/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "GNOME development shell for Nix";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    mkDevShell = system: {
+      default = nixpkgs.legacyPackages.${system}.mkShell {
+        # shellHook = "exec /run/current-system/sw/bin/zsh";
+        buildInputs = with nixpkgs.legacyPackages.${system}; [
+          gtk3
+        ] ++ (with python313Packages; [
+          darkdetect
+          pycairo
+          pygobject3
+        ]);
+      };
+    };
+  in {
+    devShells = nixpkgs.lib.genAttrs supportedSystems (system: mkDevShell system);
+  };
+}


### PR DESCRIPTION
Adds a GNOME app having only a text box that reacts on key strokes.

- When the user enters text, the Rust service is called.
- <kbd>Escape</kbd> or <kbd>Ctrl</kbd>+<kbd>Space</kbd> closes the application window.

## Launch

To install dependencies a Flake is provided to allow development on NixOS.

```console
$ nix develop
$ python LindosTrayApp/app.py
```

## Screenshot

<img width="889" height="273" alt="image" src="https://github.com/user-attachments/assets/2a721b20-bfc6-47b8-9835-d6966c199d84" />

