### PR TITLE
Use just commands in GHA workflow for Python

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,4 @@
-name: Python Tests
+name: Python
 
 on:
   push:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,4 +1,4 @@
-name: Rust Tests
+name: Rust
 
 on:
   push:


### PR DESCRIPTION
We can make your code base more DRY by using the just recipes we use locally also in GHA workflows.